### PR TITLE
Stop the watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # inwatch
 
+<a href="https://www.npmjs.com/package/inwatch"><img src="https://img.shields.io/npm/v/inwatch?style=flat-square"></a>
+
 > Filesystem watcher that spawns inotifywait
 
 I made this because I needed a filesystem watcher that works with [bun](https://github.com/oven-sh/bun).
+
+## Watch API
 
 Watching files with a `chokidar`-like API:
 
@@ -28,7 +32,20 @@ watcher.on("change", ({ path }) => {
 watcher.on("remove", ({ path }) => {
   console.log(`"${path}" was removed!`)
 })
+
+await watcher.stop()
 ```
+
+### Options
+
+- `recursive`: watch directories recursively (default: `false`)
+- `allow`: only emit events for paths matching the regular expression (default: `undefined`)
+- `reject`: do not emit events for paths matching the regular expression (default: `undefined`)
+- `ignoreInitial`: do not emit `add` events for existing files at startup (default: `false`)
+- `ignoreSubsequent`: emits `add` events at startup but disables the watcher (default: `false`)
+- `ignoreDuplicatesMs`: ignore duplicate events emitted by `inotifywait` within the given window (default: `undefined`)
+
+## Wait API
 
 Using the `inotifywait` wrapper directly:
 
@@ -48,6 +65,6 @@ waiter.on("all", ({ event, watchPath, eventPath }) => {
 
 ```
 
-Thanks
+## Thanks
 
 - [Anadian/regex-translator](https://github.com/Anadian/regex-translator) - adapted code from this library to convert JS RegExps to extended.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inwatch",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Filesystem watcher that spawns inotifywait.",
   "license": "MIT",
   "author": {
@@ -14,7 +14,8 @@
   "keywords": [
     "watch",
     "watcher",
-    "inotify"
+    "inotify",
+    "bun"
   ],
   "scripts": {
     "build": "tsc --project .",


### PR DESCRIPTION
- Changes `Wait.close` to `Wait.stop` to avoid ambiguity with `close` event
- Adds `Watch.stop()`
- `recursive: false` is now respected by initial scan

Fixes #7 